### PR TITLE
Fix: タイムライン画面のモーダルで違うメモが表示されてしまう。

### DIFF
--- a/src/lib/components/EditNoteModal.svelte
+++ b/src/lib/components/EditNoteModal.svelte
@@ -51,7 +51,7 @@
 			/>
 
 			<div class="max-h-[60vh] overflow-y-auto">
-				<MilkdownEditor initialContent={content} on:change={handleContentChange} />
+				<MilkdownEditor initialContent={note.content} on:change={handleContentChange} />
 			</div>
 
 			<div class="modal-action mt-6">


### PR DESCRIPTION
## 概要

- Issue  #60 で言及されていた、モーダル展開時に`content`がワンテンポ遅れて注入されるバグを修正しました

## 原因

自分の理解が間違っていなければ、この箇所の処理は以下の順序で行われているはずです

1. 親コンポーネントから`$props`を受け取る
2. 最初の描画が行われる（`MilkdownEditor`が`initialContent`を受け取る）
3. 初期化に伴い`$effect`内が実行され、`$state`（`title`, `content`）が更新される
4. `title`の変更を検知して`input`が再描画される

なので、(3)でstateに値が入るタイミングでは既に、(2)の`MilkdownEditor`の描画が完了していることになります

## 修正点

- `$props`から受け取った`note.content`をそのまま`MilkdownEditor`の`initialContent`に与えるようにしました
