### PR TITLE
Fix: テーマの切り替えトグルをスイッチしても、テーマが切り替わらない。

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,9 +1,11 @@
 @import 'tailwindcss';
 @plugin '@tailwindcss/typography';
-@plugin "daisyui";
+@plugin "daisyui" {
+	themes: false;
+}
 
 @plugin "daisyui/theme" {
-	name: 'sazanami days';
+	name: 'sazanami-days';
 	default: true;
 	prefersdark: false;
 	color-scheme: 'light';
@@ -38,9 +40,9 @@
 }
 
 @plugin "daisyui/theme" {
-	name: 'sazanami night';
+	name: 'sazanami-night';
 	default: false;
-	prefersdark: true;
+	prefersdark: false;
 	color-scheme: 'dark';
 	--color-base-100: oklch(30% 0.056 229.695);
 	--color-base-200: oklch(39% 0.07 227.392);

--- a/src/app.html
+++ b/src/app.html
@@ -7,6 +7,11 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		%sveltekit.head%
 		<script>
+			const theme = localStorage.getItem('theme');
+			if (theme) {
+				document.documentElement.setAttribute("data-theme", theme);
+			}
+
 			if ('serviceWorker' in navigator) {
 				window.addEventListener('load', () => {
 					navigator.serviceWorker


### PR DESCRIPTION
## 概要
- Issue #47 を修正しました

## 原因
- daisyuiの仕様で、`prefersdark`に指定したテーマを`data-theme`で上書きすることができないようでした
    - https://github.com/saadeghi/daisyui/issues/3754

## 修正点
1. `sazanami-night`の`prefersdark`の無効化
    - `prefersdark`を使用しないことで、`data-theme`からの切り替えが効くようになります
    - ブラウザのテーマ設定（`prefers-color-scheme`）は`theme.ts`で読み込んでいるためロジックに変更はありません
3. デフォルトテーマの無効化
    - 修正1により、テーマ設定が読み出されるまでの間、デフォルトのダークテーマが適用されるようになります
    - これを無効化することで、設定が反映されるまで`sazanami-days`が適用されるようになります
4. `app.html`でのテーマ読み込み
    - 修正2により、ダークテーマを指定している場合であっても、ページロードした瞬間は`sazanami-days`が適用されてしまいます
    - DOM読み込み時に一度`loacalStorage`を読むことで、ページロードから`onMount`までのタイムラグをカバーしています
 
## 動作確認
- [x] `prefers-color-scheme: light`環境下での初回閲覧時のテーマ反映
- [x] `prefers-color-scheme: dark`環境下での初回閲覧時のテーマ反映
- [x] `prefers-color-scheme: light`環境下でのテーマ切り替え
- [x] `prefers-color-scheme: dark`環境下でのテーマ切り替え
- [x] `prefers-color-scheme: light`環境下でのリロード時のテーマ反映
- [x] `prefers-color-scheme: dark`環境下でのリロード時のテーマ反映

