### PR TITLE
feat: improve timeline note creation and profile settings

### DIFF
--- a/src/lib/components/CreateNoteModal.svelte
+++ b/src/lib/components/CreateNoteModal.svelte
@@ -12,6 +12,7 @@
 	let dialog: HTMLDialogElement;
 	let title = $state('');
 	let content = $state('');
+	let showTitleInput = $state(false);
 
 	$effect(() => {
 		if (open) {
@@ -23,6 +24,7 @@
 				dialog.close();
 				title = '';
 				content = '';
+				showTitleInput = false;
 			}
 		}
 	});
@@ -34,16 +36,36 @@
 	function handleClose() {
 		dispatch('cancel');
 	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+			e.preventDefault();
+			if (!saving) {
+				handleSave();
+			}
+		}
+	}
 </script>
 
-<dialog bind:this={dialog} class="modal" onclose={handleClose}>
+<dialog bind:this={dialog} class="modal" onclose={handleClose} onkeydown={handleKeydown}>
 	<div class="modal-box w-11/12 max-w-4xl">
-		<input
-			type="text"
-			bind:value={title}
-			class="input input-bordered bg-base-200 mb-4 w-full text-lg font-bold"
-			placeholder="タイトル"
-		/>
+		{#if showTitleInput || title}
+			<input
+				type="text"
+				bind:value={title}
+				class="input input-bordered bg-base-200 mb-4 w-full text-lg font-bold"
+				placeholder="タイトル"
+			/>
+		{:else}
+			<button
+				class="btn btn-ghost btn-sm mb-4 text-xs font-normal opacity-60 hover:opacity-100"
+				onclick={() => {
+					showTitleInput = true;
+				}}
+			>
+				Add title
+			</button>
+		{/if}
 
 		<div class="max-h-[60vh] min-h-[300px] overflow-y-auto">
 			<TiptapEditor bind:content />

--- a/src/lib/components/EditNoteModal.svelte
+++ b/src/lib/components/EditNoteModal.svelte
@@ -41,9 +41,18 @@
 		// We dispatch 'cancel' to let the parent know it should set its note state to null.
 		dispatch('cancel');
 	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+			e.preventDefault();
+			if (!saving) {
+				handleSave();
+			}
+		}
+	}
 </script>
 
-<dialog bind:this={dialog} class="modal" onclose={handleClose}>
+<dialog bind:this={dialog} class="modal" onclose={handleClose} onkeydown={handleKeydown}>
 	<div class="modal-box w-11/12 max-w-4xl">
 		{#if note}
 			<input

--- a/src/lib/components/TimelinePost.svelte
+++ b/src/lib/components/TimelinePost.svelte
@@ -162,6 +162,10 @@
 			</div>
 		{/if}
 
+		{#if note.title && note.title !== 'Untitled Note'}
+			<h2 class="mb-2 text-xl font-bold">{note.title}</h2>
+		{/if}
+
 		<div class="prose text-base-content max-w-none">
 			{@html marked.parse(note.content || '', { breaks: true })}
 		</div>

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -12,7 +12,14 @@ export const load: LayoutServerLoad = async ({ request, url }) => {
 	});
 
 	const allowedPaths = ['/login', '/login/two-factor', '/'];
-	if (!sessionData?.session && !allowedPaths.includes(url.pathname)) {
+	const isAllowedPath =
+		allowedPaths.includes(url.pathname) ||
+		(url.pathname !== '/' && // `/` は上で処理済み
+			!url.pathname.startsWith('/home') &&
+			!url.pathname.startsWith('/settings') &&
+			!url.pathname.includes('/edit')); // /[username]/edit 等は除外
+
+	if (!sessionData?.session && !isAllowedPath) {
 		let redirectUrl = '/login';
 		if (queryParams) redirectUrl += `?${queryParams}`;
 		throw redirect(302, redirectUrl);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -140,7 +140,25 @@
 			goto('/login');
 		}
 	};
+
+	function handleGlobalKeydown(e: KeyboardEvent) {
+		if (hideShell) return;
+
+		const target = e.target as HTMLElement;
+		const isInput =
+			target.tagName === 'INPUT' ||
+			target.tagName === 'TEXTAREA' ||
+			target.tagName === 'SELECT' ||
+			target.isContentEditable;
+
+		if (!isInput && e.key === 'n' && !e.ctrlKey && !e.metaKey && !e.altKey) {
+			e.preventDefault();
+			isCreateModalOpen = true;
+		}
+	}
 </script>
+
+<svelte:window onkeydown={handleGlobalKeydown} />
 
 <svelte:head>
 	{#if fontSetting === 'Noto Sans JP'}

--- a/src/routes/[username]/+page.svelte
+++ b/src/routes/[username]/+page.svelte
@@ -88,8 +88,12 @@
 								{formatDistanceToNow(new Date(note.createdAt), { addSuffix: true, locale: ja })}
 							</p>
 							<div class="card-actions mt-2 justify-end">
-								<!-- todo: 本来はノートの詳細画面などへ飛ぶ -->
-								<a href="/home/note/{note.id}" class="btn btn-ghost btn-sm">詳細</a>
+								{#if isOwner}
+									<a href="/home/note/{note.id}" class="btn btn-ghost btn-sm">詳細</a>
+								{:else}
+									<!-- 他人の公開ノートは専用ページがない場合は非表示にするか、別途実装する対応が必要 -->
+									<!-- <a href="/note/{note.id}" class="btn btn-ghost btn-sm">詳細</a> -->
+								{/if}
 							</div>
 						</div>
 					</div>

--- a/src/routes/[username]/edit/+page.server.ts
+++ b/src/routes/[username]/edit/+page.server.ts
@@ -4,6 +4,20 @@ import { db } from '$lib/server/db/connection';
 import { user, userSettings } from '$lib/server/db/schema';
 import { eq, or } from 'drizzle-orm';
 import { auth } from '$lib/server/auth';
+import fs from 'fs/promises';
+import path from 'path';
+import { ulid } from 'ulid';
+
+const UPLOAD_DIR = path.resolve(process.cwd(), 'static/uploads');
+
+const ensureUploadDir = async () => {
+	try {
+		await fs.mkdir(UPLOAD_DIR, { recursive: true });
+	} catch (error) {
+		console.error('Error creating upload directory:', error);
+		throw new Error('Could not create upload directory');
+	}
+};
 
 export const load: PageServerLoad = async ({ params, locals }) => {
 	const identifier = params.username;
@@ -19,6 +33,7 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 			id: user.id,
 			name: user.name,
 			username: user.username,
+			image: user.image,
 			bio: userSettings.bio
 		})
 		.from(user)
@@ -51,6 +66,7 @@ export const actions: Actions = {
 		const name = formData.get('name')?.toString().trim();
 		const username = formData.get('username')?.toString().trim() || null;
 		const bio = formData.get('bio')?.toString() || '';
+		const imageFile = formData.get('image') as File | null;
 
 		if (!name) {
 			return fail(400, { name, username, bio, error: '名前は必須です' });
@@ -80,13 +96,31 @@ export const actions: Actions = {
 				});
 			}
 
+			// 画像ファイルの保存処理
+			let imageUrl: string | undefined = undefined;
+			if (imageFile && imageFile.size > 0) {
+				await ensureUploadDir();
+				const uniqueId = ulid();
+				const fileExtension = path.extname(imageFile.name);
+				const uniqueFileName = `avatar_${uniqueId}${fileExtension}`;
+				const filePath = path.join(UPLOAD_DIR, uniqueFileName);
+
+				const buffer = await imageFile.arrayBuffer();
+				await fs.writeFile(filePath, Buffer.from(buffer));
+
+				imageUrl = `/uploads/${uniqueFileName}`;
+			}
+
 			// better-authのUpdateUser APIを利用してユーザー情報を更新
+			// authのcontextを構築して updateUser を呼び出す
+			const updateData: any = { name, username };
+			if (imageUrl) {
+				updateData.image = imageUrl;
+			}
+
 			await auth.api.updateUser({
 				headers: event.request.headers,
-				body: {
-					name,
-					username
-				}
+				body: updateData
 			});
 		} catch (err: any) {
 			console.error('Failed to update profile:', err);

--- a/src/routes/[username]/edit/+page.svelte
+++ b/src/routes/[username]/edit/+page.svelte
@@ -6,6 +6,19 @@
 	export let form: ActionData;
 
 	let submitting = false;
+	let imagePreview = data.profile.user?.image || null;
+
+	function handleImageSelect(event: Event) {
+		const target = event.target as HTMLInputElement;
+		const file = target.files?.[0];
+		if (file) {
+			const reader = new FileReader();
+			reader.onload = (e) => {
+				imagePreview = e.target?.result as string;
+			};
+			reader.readAsDataURL(file);
+		}
+	}
 </script>
 
 <svelte:head>
@@ -42,6 +55,7 @@
 
 			<form
 				method="POST"
+				enctype="multipart/form-data"
 				use:enhance={() => {
 					submitting = true;
 					return async ({ update }) => {
@@ -51,6 +65,36 @@
 				}}
 				class="space-y-6"
 			>
+				<!-- Profile Image -->
+				<div class="form-control w-full">
+					<label class="label" for="image">
+						<span class="label-text font-semibold">プロフィール画像</span>
+					</label>
+					<div class="flex items-center gap-4">
+						<div class="avatar">
+							<div class="ring-primary ring-offset-base-100 w-24 rounded-full ring ring-offset-2">
+								{#if imagePreview}
+									<img src={imagePreview} alt="プロフィールプレビュー" />
+								{:else}
+									<div
+										class="bg-neutral text-neutral-content flex h-full w-full items-center justify-center text-2xl font-bold"
+									>
+										{data.profile.name?.charAt(0) || '?'}
+									</div>
+								{/if}
+							</div>
+						</div>
+						<input
+							type="file"
+							id="image"
+							name="image"
+							accept="image/*"
+							class="file-input file-input-bordered w-full max-w-xs"
+							on:change={handleImageSelect}
+						/>
+					</div>
+				</div>
+
 				<!-- 表示名 -->
 				<div class="form-control w-full">
 					<label class="label" for="name">

--- a/src/routes/api/notes/+server.ts
+++ b/src/routes/api/notes/+server.ts
@@ -141,17 +141,14 @@ export const POST: RequestHandler = async ({ request }) => {
 		let noteTitle = title;
 		const noteContent = content || '';
 
-		// タイムラインや新規作成からのポストの場合、タイトルが未指定（undefined または空文字）であれば自動生成
+		// タイムラインや新規作成からのポストの場合、タイトルが未指定（undefined または空文字）であれば自動生成...しない
 		if (title === undefined || title.trim() === '') {
-			const firstLine = noteContent.split('\n')[0] || '';
-			// 本文からHTMLタグを除去し、最初の50文字をタイトルとする
-			const plainTextFirstLine = firstLine.replace(/<[^>]*>/g, '').trim();
-			noteTitle = plainTextFirstLine.substring(0, 50) || 'Untitled Note';
+			noteTitle = '';
 		} else {
-			noteTitle = title.trim() || 'Untitled Note';
+			noteTitle = title.trim();
 		}
 
-		const noteSlug = generateSlug(noteTitle); // スラッグを生成
+		const noteSlug = noteTitle ? generateSlug(noteTitle) : noteId; // タイトルが空の場合はIDをスラッグにする
 
 		// 新規メモを作成
 		await db.insert(notes).values({


### PR DESCRIPTION
## 変更内容
- タイムラインでのノート作成時、タイトル入力欄をデフォルトで非表示にし、「Add title」ボタンで表示するように修正
- タイムラインや新規作成時に、タイトル未入力時に本文から自動でタイトルを生成する処理を削除し、空文字で保存するよう修正
- タイムラインのノート表示で、タイトルが存在する場合に表示するように修正
- ノート作成・編集モーダルで、`Ctrl+Enter` (または `Cmd+Enter`) でノートを投稿できるようにショートカットを追加
- 文字入力中以外に `n` キーを押すことで新規ノート作成モーダルを開くショートカットを追加
- ヘッダーのユーザーアイコンからプロフィールページへ遷移できることを確認
- プロフィール編集画面にて、アイコン画像を選択フォーマットでサーバーの `static/uploads` にアップロードし保存する機能を追加
- 未ログイン状態でも、各ユーザーのプロフィール画面（および公開に設定されたノート）を閲覧できるようにルートレイアウトの設定を変更