### PR TITLE
fix: update GitHub Actions workflows after monorepo flattening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         run: bunx prettier --check .
         continue-on-error: true
       - name: Svelte Check
-        run: bun run --filter sazanami-web check
+        run: bun run check
 
   unit-tests:
     name: Unit Tests
@@ -35,7 +35,7 @@ jobs:
       - name: Install dependencies
         run: bun install
       - name: Run unit tests
-        run: bun run --filter sazanami-web test:unit -- --run
+        run: bun run test:unit -- --run
 
   e2e-tests:
     name: E2E Tests (Playwright)
@@ -51,24 +51,24 @@ jobs:
       - name: Install Playwright browsers
         run: bunx playwright install chromium --with-deps
       - name: Copy .env for test DB
-        run: cp apps/web/.env.example apps/web/.env
+        run: cp .env.example .env
       - name: Run database migration
-        run: bun run --filter sazanami-web db:migrate
+        run: bun run db:migrate
       - name: Run Playwright tests
-        run: bun run --filter sazanami-web test:e2e
+        run: bun run test:e2e
       - name: Upload Playwright report (on failure)
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report
-          path: apps/web/playwright-report/
+          path: playwright-report/
           retention-days: 7
       - name: Upload test results (on failure)
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: test-results
-          path: apps/web/test-results/
+          path: test-results/
           retention-days: 7
 
   build:
@@ -83,4 +83,4 @@ jobs:
       - name: Install dependencies
         run: bun install
       - name: Build
-        run: bun run --filter sazanami-web build
+        run: bun run build

--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -5,8 +5,8 @@ on:
     branches:
       - main
     paths:
-      - 'apps/web/drizzle/**'
-      - 'apps/web/src/lib/server/db/schema.ts'
+      - 'drizzle/**'
+      - 'src/lib/server/db/schema.ts'
 
 jobs:
   db-migrate:
@@ -27,4 +27,4 @@ jobs:
         env:
           TURSO_DATABASE_URL: ${{ secrets.TURSO_DATABASE_URL }}
           TURSO_AUTH_TOKEN: ${{ secrets.TURSO_AUTH_TOKEN }}
-        run: bun run --filter sazanami-web db:migrate
+        run: bun run db:migrate

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy-web:
-    name: Deploy sazanami-web
+    name: Deploy sazanami
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
@@ -18,11 +18,10 @@ jobs:
       - name: Install dependencies
         run: bun install
       - name: Build
-        run: bun run --filter sazanami-web build
+        run: bun run build
       - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: apps/web
           command: deploy


### PR DESCRIPTION
## Summary

After the monorepo flattening (PR #164), GitHub Actions workflows were broken because they still referenced `apps/web/` paths and used `--filter sazanami-web`.

## Changes

- **ci.yml**: Removed all `--filter sazanami-web` prefixes, fixed paths (`apps/web/.env.example` → `.env.example`, `apps/web/playwright-report/` → `playwright-report/`, etc.)
- **db-migrate.yml**: Fixed trigger paths (`apps/web/drizzle/**` → `drizzle/**`), removed `--filter`
- **deploy.yml**: Updated paths, removed `workingDirectory: apps/web`